### PR TITLE
fixes compilation waring

### DIFF
--- a/backend/test/support/mocks.ex
+++ b/backend/test/support/mocks.ex
@@ -1,0 +1,5 @@
+defmodule Mocks do
+  @moduledoc false
+
+  Mox.defmock(GrumpyCatWeb.ReverseGeocoding.Mock, for: GrumpyCatWeb.ReverseGeocoding)
+end

--- a/backend/test/test_helper.exs
+++ b/backend/test/test_helper.exs
@@ -1,4 +1,2 @@
 ExUnit.start()
 Ecto.Adapters.SQL.Sandbox.mode(GrumpyCat.Repo, :manual)
-
-Mox.defmock(GrumpyCatWeb.ReverseGeocoding.Mock, for: GrumpyCatWeb.ReverseGeocoding)


### PR DESCRIPTION
As stated [here](https://hexdocs.pm/mox/Mox.html#module-compile-time-requirements) mocks may get a compilation warning. This PR fixes it.